### PR TITLE
Fix image in archived post

### DIFF
--- a/archive/_posts/2020-04-18-response-to-the-changeorg-petition-about-me.md
+++ b/archive/_posts/2020-04-18-response-to-the-changeorg-petition-about-me.md
@@ -13,7 +13,7 @@ custom_excerpt: "A rebuttal to the claims made about me in a Change.org petition
 
 I'm pleased to write that Change.org has come to a decision on my report and removed the petition as a violation of their community guidelines:
 
-!<img src="https://i.imgur.com/BUExEGO.png" alt="Change.org email reply" />
+<img src="https://i.imgur.com/BUExEGO.png" alt="Change.org email reply" />
 
 I will leave this post in place, as I do think it provides useful background into this issue with Epik, which appears to be ongoing.
 


### PR DESCRIPTION
looks like the image was working [in September 2020](https://archive.today/s3O4N) (after the post was archived) but now the file it requests doesn't exist

The [only other post](https://blog.mollywhite.net/notion/) to use an image used Imgur so changed it to that instead

